### PR TITLE
modifica comandos para recibir access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ php artisan migrate
 ## Usage
 
 ``` bash
-php artisan import:states-from AR
-php artisan import:cities
-php artisan import:neighborhoods
+php artisan import:states-from AR <token>
+php artisan import:cities <token>
+php artisan import:neighborhoods <token>
 ```
+
+> NOTE: You need to generate an access token. You can do that <a href="https://meli.tepuilabs.dev/" target="_blank">here</a>.
 
 <details>
     <summary>country list:</summary>

--- a/src/Commands/CitiesCommand.php
+++ b/src/Commands/CitiesCommand.php
@@ -16,7 +16,7 @@ class CitiesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'import:cities';
+    protected $signature = 'meli:cities {token}';
 
     /**
      * The console command description.
@@ -44,9 +44,11 @@ class CitiesCommand extends Command
     {
         $states = \Abr4xas\Location\Models\State::pluck('code', 'id');
 
+        $token = $this->argument('token');
+
         $this->getOutput()->progressStart(count($states));
         foreach ($states as $id => $code) {
-            $cityResponse = $this->makeRequest('https://api.mercadolibre.com/classified_locations/states/' . $code);
+            $cityResponse = $this->makeRequest($token, 'https://api.mercadolibre.com/classified_locations/states/' . $code);
             $cities = $cityResponse->json();
 
             foreach ($cities['cities'] as $key) {

--- a/src/Commands/LocationCommand.php
+++ b/src/Commands/LocationCommand.php
@@ -16,7 +16,7 @@ class LocationCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'import:states-from';
+    protected $signature = 'meli:states-from {country} {token}';
 
     /**
      * The console command description.
@@ -42,10 +42,11 @@ class LocationCommand extends Command
      */
     public function handle()
     {
-        $country = $this->ask('What is your country code?');
+        $country = $this->argument('country');
+        $token = $this->argument('token');
 
         if ($this->confirm('Do you wish to continue?', true)) {
-            $statesResponse = $this->makeRequest('https://api.mercadolibre.com/classified_locations/countries/'. $country);
+            $statesResponse = $this->makeRequest($token, 'https://api.mercadolibre.com/classified_locations/countries/'. $country);
 
             $states = $statesResponse->json();
 

--- a/src/Commands/NeighborhoodsCommand.php
+++ b/src/Commands/NeighborhoodsCommand.php
@@ -16,7 +16,7 @@ class NeighborhoodsCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'import:neighborhoods';
+    protected $signature = 'meli:neighborhoods {token}';
 
     /**
      * The console command description.
@@ -44,9 +44,11 @@ class NeighborhoodsCommand extends Command
     {
         $cities = \Abr4xas\Location\Models\City::pluck('code', 'id');
 
+        $token = $this->argument('token');
+
         $this->getOutput()->progressStart(count($cities));
         foreach ($cities as $id => $code) {
-            $neighborhoodsResponse = $this->makeRequest('https://api.mercadolibre.com/classified_locations/cities/' . $code);
+            $neighborhoodsResponse = $this->makeRequest($token, 'https://api.mercadolibre.com/classified_locations/cities/' . $code);
             $neighborhoods = $neighborhoodsResponse->json();
 
             if (! empty($neighborhoods['neighborhoods'])) {

--- a/src/Traits/MakeRequestTrait.php
+++ b/src/Traits/MakeRequestTrait.php
@@ -9,8 +9,8 @@ trait MakeRequestTrait
      * @param string $url
      * @return \Illuminate\Http\Client\Response
      */
-    public function makeRequest(string $url)
+    public function makeRequest(string $token, string $url)
     {
-        return \Illuminate\Support\Facades\Http::get($url);
+        return \Illuminate\Support\Facades\Http::withToken($token)->get($url);
     }
 }

--- a/tests/Feature/Commands/LocationCommandTest.php
+++ b/tests/Feature/Commands/LocationCommandTest.php
@@ -3,14 +3,24 @@ namespace Abr4xas\Location\Tests\Feature\Commands;
 
 use Abr4xas\Location\Commands\LocationCommand;
 use Abr4xas\Location\Tests\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 class LocationCommandTest extends TestCase
 {
     /** @test */
+    public function test_importing_without_arguments()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->artisan(LocationCommand::class);
+    }
+
+    /** @test */
     public function test_if_can_import_country_data()
     {
-        $this->artisan(LocationCommand::class)
-            ->expectsQuestion('What is your country code?', 'AR')
+        $this->artisan(LocationCommand::class, [
+                'country' => 'AR',
+                'token' => 'AR',
+            ])
             ->expectsConfirmation('Do you wish to continue?', false)
             ->expectsOutput('Ok...')
             ->assertExitCode(0);


### PR DESCRIPTION
mercado libre ahora necesita recibir un bearer token para poder acceder a los endpoints de las api.